### PR TITLE
Add support for ruby 2.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 
 rvm:
-  - "2.4.0"
+  - "2.3.0"
   - "2.5.0"
 
 notifications:

--- a/lp.gemspec
+++ b/lp.gemspec
@@ -14,5 +14,5 @@ Gem::Specification.new do |s|
   s.files       = Dir['README.md', 'lib/**/*.*']
   s.homepage    = 'https://github.com/dannyben/lp'
   s.license     = 'MIT'
-  s.required_ruby_version = ">= 2.4.0"
+  s.required_ruby_version = ">= 2.3.0"
 end


### PR DESCRIPTION
There was no reason for the 2.4 constraint. Reduced to 2.3.